### PR TITLE
Update classifiers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Python 3.8 appears unsupported (`requires-python = ">=3.9.0"`). Therefore corresponding classifier should be removed