### PR TITLE
add get_std() to simulators

### DIFF
--- a/qokit/fur/c/qaoa_simulator.py
+++ b/qokit/fur/c/qaoa_simulator.py
@@ -3,14 +3,16 @@
 # // Copyright : JP Morgan Chase & Co
 ###############################################################################
 from __future__ import annotations
+
 from collections.abc import Sequence
+
 import numpy as np
 
-from ..qaoa_simulator_base import QAOAFastSimulatorBase, CostsType, TermsType, ParamType
 from ..diagonal_precomputation import precompute_vectorized_cpu_parallel
-
-from .gates import ComplexArray
+from ..qaoa_simulator_base import (CostsType, ParamType, QAOAFastSimulatorBase,
+                                   TermsType)
 from . import csim
+from .gates import ComplexArray
 
 
 class QAOAFastSimulatorCBase(QAOAFastSimulatorBase):
@@ -58,6 +60,12 @@ class QAOAFastSimulatorCBase(QAOAFastSimulatorBase):
         if optimization_type == "max":
             costs = -1 * np.asarray(costs)
         return np.dot(costs, self.get_probabilities(result, **kwargs))
+
+    def get_std(self, result: ComplexArray, costs: np.ndarray | None = None, **kwargs) -> float:
+        if costs is None:
+            costs = self._hc_diag
+        probs = self.get_probabilities(result)
+        return np.sqrt(max(np.dot(costs**2, probs) - np.dot(costs, probs) ** 2, 0))
 
     def get_overlap(
         self, result: ComplexArray, costs: CostsType | None = None, indices: np.ndarray | Sequence[int] | None = None, optimization_type="min", **kwargs

--- a/qokit/fur/c/qaoa_simulator.py
+++ b/qokit/fur/c/qaoa_simulator.py
@@ -9,8 +9,7 @@ from collections.abc import Sequence
 import numpy as np
 
 from ..diagonal_precomputation import precompute_vectorized_cpu_parallel
-from ..qaoa_simulator_base import (CostsType, ParamType, QAOAFastSimulatorBase,
-                                   TermsType)
+from ..qaoa_simulator_base import CostsType, ParamType, QAOAFastSimulatorBase, TermsType
 from . import csim
 from .gates import ComplexArray
 

--- a/qokit/fur/lazy_import.py
+++ b/qokit/fur/lazy_import.py
@@ -25,3 +25,4 @@ class LasyModule:
 
 
 MPI = LasyModule("mpi4py.MPI")
+pkl5 = LasyModule("mpi4py.util.pkl5")

--- a/qokit/fur/mpi_nbcuda/qaoa_simulator.py
+++ b/qokit/fur/mpi_nbcuda/qaoa_simulator.py
@@ -15,13 +15,10 @@ from qokit.fur.nbcuda.qaoa_simulator import DeviceArray
 
 from ..diagonal_precomputation import precompute_gpu
 from ..lazy_import import MPI, pkl5
-from ..nbcuda.qaoa_simulator import (CostsType, ParamType,
-                                     QAOAFastSimulatorGPUBase, TermsType)
-from ..nbcuda.utils import (copy, initialize_uniform, multiply, norm_squared,
-                            sum_reduce)
+from ..nbcuda.qaoa_simulator import CostsType, ParamType, QAOAFastSimulatorGPUBase, TermsType
+from ..nbcuda.utils import copy, initialize_uniform, multiply, norm_squared, sum_reduce
 from .compute_costs import compute_costs, zero_init
-from .qaoa_fur import \
-    apply_qaoa_furx  # , apply_qaoa_furxy_complete, apply_qaoa_furxy_ring
+from .qaoa_fur import apply_qaoa_furx  # , apply_qaoa_furxy_complete, apply_qaoa_furxy_ring
 
 
 def mpi_available(allow_single_process=False):

--- a/qokit/fur/mpi_nbcuda/qaoa_simulator.py
+++ b/qokit/fur/mpi_nbcuda/qaoa_simulator.py
@@ -14,7 +14,7 @@ import numpy as np
 from qokit.fur.nbcuda.qaoa_simulator import DeviceArray
 
 from ..diagonal_precomputation import precompute_gpu
-from ..lazy_import import MPI
+from ..lazy_import import MPI, pkl5
 from ..nbcuda.qaoa_simulator import (CostsType, ParamType,
                                      QAOAFastSimulatorGPUBase, TermsType)
 from ..nbcuda.utils import (copy, initialize_uniform, multiply, norm_squared,
@@ -71,7 +71,7 @@ def get_costs(terms, N, rank=0):
 
 class QAOAFastSimulatorGPUMPIBase(QAOAFastSimulatorGPUBase):
     def __init__(self, n_qubits: int, costs: CostsType | None = None, terms: TermsType | None = None) -> None:
-        self._comm = MPI.COMM_WORLD
+        self._comm = pkl5.Intracomm(MPI.COMM_WORLD)
         self._rank = self._comm.Get_rank()
         self._size = self._comm.Get_size()
         _set_gpu_device_roundrobin()

--- a/qokit/fur/nbcuda/qaoa_simulator.py
+++ b/qokit/fur/nbcuda/qaoa_simulator.py
@@ -13,10 +13,8 @@ import numpy as np
 from qokit.fur.qaoa_simulator_base import TermsType
 
 from ..diagonal_precomputation import precompute_gpu
-from ..qaoa_simulator_base import (CostsType, ParamType, QAOAFastSimulatorBase,
-                                   TermsType)
-from .qaoa_fur import (apply_qaoa_furx, apply_qaoa_furxy_complete,
-                       apply_qaoa_furxy_ring)
+from ..qaoa_simulator_base import CostsType, ParamType, QAOAFastSimulatorBase, TermsType
+from .qaoa_fur import apply_qaoa_furx, apply_qaoa_furxy_complete, apply_qaoa_furxy_ring
 from .utils import copy, initialize_uniform, multiply, norm_squared, sum_reduce
 
 DeviceArray = numba.cuda.devicearray.DeviceNDArray

--- a/qokit/fur/python/qaoa_simulator.py
+++ b/qokit/fur/python/qaoa_simulator.py
@@ -9,10 +9,8 @@ from collections.abc import Sequence
 import numpy as np
 
 from ..diagonal_precomputation import precompute_vectorized_cpu_parallel
-from ..qaoa_simulator_base import (CostsType, ParamType, QAOAFastSimulatorBase,
-                                   TermsType)
-from .qaoa_fur import (apply_qaoa_furx, apply_qaoa_furxy_complete,
-                       apply_qaoa_furxy_ring)
+from ..qaoa_simulator_base import CostsType, ParamType, QAOAFastSimulatorBase, TermsType
+from .qaoa_fur import apply_qaoa_furx, apply_qaoa_furxy_complete, apply_qaoa_furxy_ring
 
 
 def little_to_big_endian(arr):

--- a/qokit/fur/python/qaoa_simulator.py
+++ b/qokit/fur/python/qaoa_simulator.py
@@ -3,11 +3,16 @@
 # // Copyright : JP Morgan Chase & Co
 ###############################################################################
 from __future__ import annotations
+
 from collections.abc import Sequence
+
 import numpy as np
-from ..qaoa_simulator_base import QAOAFastSimulatorBase, CostsType, TermsType, ParamType
+
 from ..diagonal_precomputation import precompute_vectorized_cpu_parallel
-from .qaoa_fur import apply_qaoa_furx, apply_qaoa_furxy_complete, apply_qaoa_furxy_ring
+from ..qaoa_simulator_base import (CostsType, ParamType, QAOAFastSimulatorBase,
+                                   TermsType)
+from .qaoa_fur import (apply_qaoa_furx, apply_qaoa_furxy_complete,
+                       apply_qaoa_furxy_ring)
 
 
 def little_to_big_endian(arr):
@@ -72,6 +77,12 @@ class QAOAFastSimulatorPythonBase(QAOAFastSimulatorBase):
         if optimization_type == "max":
             return -1 * np.dot(costs, np.abs(result) ** 2)
         return np.dot(costs, np.abs(result) ** 2)
+
+    def get_std(self, result: np.ndarray, costs: np.ndarray | None = None, **kwargs) -> float:
+        if costs is None:
+            costs = self._hc_diag
+        probs = np.abs(result) ** 2
+        return np.sqrt(max(np.dot(costs**2, probs) - np.dot(costs, probs) ** 2, 0))
 
     def get_overlap(
         self, result: np.ndarray, costs: CostsType | None = None, indices: np.ndarray | Sequence[int] | None = None, optimization_type="min", **kwargs

--- a/qokit/fur/qaoa_simulator_base.py
+++ b/qokit/fur/qaoa_simulator_base.py
@@ -3,10 +3,12 @@
 # // Copyright : JP Morgan Chase & Co
 ###############################################################################
 from __future__ import annotations
-import typing
-import numpy as np
-from abc import ABC, abstractmethod
+
 import sys
+import typing
+from abc import ABC, abstractmethod
+
+import numpy as np
 
 # Terms are a list of tuples (coeff, [qubit indices])
 # Run this only for python> 3.9
@@ -139,6 +141,21 @@ class QAOAFastSimulatorBase(ABC):
             result: obtained from `sim.simulate_qaoa`
             costs: (optional) array containing values of the cost function at
                 each computational basis state. Accepted types depend on the implementation.
+            **kwargs : additional arguments for the simulator depending on the implementation
+        """
+        ...
+
+    @abstractmethod
+    def get_std(self, result, costs: typing.Any = None, **kwargs) -> float:
+        """
+        Return the standard deviation of the expectation of the cost Hamiltonian
+
+        Parameters
+        ----------
+            result: obtained from `sim.simulate_qaoa`
+            costs: (optional) array containing values of the cost function at
+                each computational basis state. Accepted types depend on the implementation.
+            **kwargs : additional arguments for the simulator depending on the implementation
         """
         ...
 
@@ -166,6 +183,7 @@ class QAOAFastSimulatorBase(ABC):
         Parameters
         ----------
             result: obtained from `sim.simulate_qaoa`
+            **kwargs : additional arguments for the simulator depending on the implementation
         """
         ...
 
@@ -177,5 +195,6 @@ class QAOAFastSimulatorBase(ABC):
         Parameters
         ----------
             result: obtained from `sim.simulate_qaoa`
+            **kwargs : additional arguments for the simulator depending on the implementation
         """
         ...

--- a/qokit/qaoa_objective.py
+++ b/qokit/qaoa_objective.py
@@ -16,8 +16,7 @@ from qiskit import Aer, execute
 import qokit.parameter_utils
 from qokit.parameter_utils import QAOAParameterization
 
-from .fur import (QAOAFastSimulatorBase, choose_simulator,
-                  choose_simulator_xyring)
+from .fur import QAOAFastSimulatorBase, choose_simulator, choose_simulator_xyring
 from .fur.diagonal_precomputation import precompute_vectorized_cpu_parallel
 from .parameter_utils import from_fourier_basis
 from .qaoa_circuit_portfolio import measure_circuit


### PR DESCRIPTION
Added native implementation calculating the standard deviation to all simulators. Tried my best to support as large a scale as possible and avoid unnecessary duplicate computations.
Bonus: `get_qaoa_objective()` now can accept a sequence of strings as its objective (see https://github.com/jpmorganchase/jpmc-argonne-quantum-optimization/issues/169), so no more "expectation and overlap".
Also, #42 is addressed but has not been tested yet.