### PR TITLE
Remove qiskit-terra explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     'qiskit>=0.42,<1',
     'qiskit-finance>=0.3,<1',
     'qiskit-ibmq-provider>=0.20.2,<1',
-    'qiskit-terra>=0.23.2,<1',
     'scipy>=1.10.1',
     'seaborn>=0.12.2',
     'sympy>=1.12',


### PR DESCRIPTION
`qiskit-terra` is part of the `qiskit<1` meta-package. Keeping the double-dependency is redundant and forces to keep them in track. Additionally, `qiskit-terra` is sunsetting:

https://docs.quantum.ibm.com/api/migration-guides/qiskit-1.0-installation#the-old-qiskit-structure