### PR TITLE
Faster X-Rotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install -e .
 
 Some optional parts of the package require additional dependencies. 
 - GPU simulation: `pip install -e .[GPU-CUDA12]`
-- Generating LP files to solve LABS using commercial IP solvers (`qokit/classical_methods`): `pip install -e .[solvers]`
+- Generating LP files to solve LABS using commercial IP solvers (`qokit/classical_methods` and `examples/advanced/classical_solvers_for_LABS/`): `pip install -e .[solvers]`
 
 Please note that the GPU dependency is specified for CUDA 12x. For other versions of CUDA, please follow cupy installation instructions.
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ pip install -e .
 ```
 
 Some optional parts of the package require additional dependencies. 
-- Using commercial IP solvers to solve optimizations problems: `pip install -e .[solvers]`
 - GPU simulation: `pip install -e .[GPU-CUDA12]`
+- Generating LP files to solve LABS using commercial IP solvers (`qokit/classical_methods`): `pip install -e .[solvers]`
 
 Please note that the GPU dependency is specified for CUDA 12x. For other versions of CUDA, please follow cupy installation instructions.
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ pip install -e .
 ```
 
 Some optional parts of the package require additional dependencies. 
-- Using commercial IP solvers to solve optimizations problems: `pip install qokit[solvers]`
-- GPU simulation: `pip install qokit[GPU]`
-- Development: `pip install qokit[dev]`
+- Using commercial IP solvers to solve optimizations problems: `pip install -e .[solvers]`
+- GPU simulation: `pip install -e .[GPU-CUDA12]`
 
+Please note that the GPU dependency is specified for CUDA 12x. For other versions of CUDA, please follow cupy installation instructions.
 
 If compilation fails, try installing just the Python version using `QOKIT_PYTHON_ONLY=1 pip install -e .`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,11 @@ dependencies = [
     'seaborn>=0.12.2',
     'sympy>=1.12',
     'tqdm>=4.65.0',
-    'cupy',
 ]
 
 [project.optional-dependencies]
-GPU = [
-  'qiskit-aer-gpu>=0.8'
+GPU-CUDA12 = [
+    'cupy-cuda12x>=13.2.0'
 ]
 dev = [
   'black[d]>=23.3.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     'seaborn>=0.12.2',
     'sympy>=1.12',
     'tqdm>=4.65.0',
+    'cupy',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,14 +41,6 @@ dependencies = [
 GPU-CUDA12 = [
     'cupy-cuda12x>=13.2.0'
 ]
-dev = [
-  'black[d]>=23.3.0',
-  'setuptools>=58.1.0',
-  'Deprecated>=1.2.13',
-  'urllib3>=1.26.6',
-  'statsmodels>=0.13.5',
-  'scikit-learn>=1.2.2'
-]
 solvers = [
   'docplex>=2.18.200',
   'gurobipy>=9.1.2'

--- a/qokit/fur/nbcuda/fur.py
+++ b/qokit/fur/nbcuda/fur.py
@@ -5,43 +5,75 @@
 import math
 import numba.cuda
 import numpy as np
-
+import cupy as cp
+from pathlib import Path
+from functools import lru_cache
 
 ########################################
 # single-qubit X rotation
 ########################################
-@numba.cuda.jit
-def furx_kernel(x, wa, wb, q, mask1, mask2):
-    """CUDA kernel for fast uniform X rotations"""
-    n_states = len(x)
-    n_groups = n_states // 2
-    tid = numba.cuda.grid(1)
-
-    if tid < n_groups:
-        ia = (tid & mask1) | ((tid & mask2) << 1)
-        ib = ia | (1 << q)
-        x[ia], x[ib] = wa * x[ia] + wb * x[ib], wb * x[ia] + wa * x[ib]
-
-
-def furx(x: np.ndarray, theta: float, q: int):
+@lru_cache
+def get_furx_kernel(k_qubits: int, q_offset: int, state_mask: int):
     """
-    Apply in-place fast Rx gate exp(-1j * theta * X) on qubit q to statevector array x.
-    theta: rotation angle
+    Generate furx kernel for the specified sub-group size.
     """
-    n_states = len(x)
-    mask1 = (1 << q) - 1
-    mask2 = mask1 ^ ((n_states - 1) >> 1)
-    furx_kernel.forall(n_states)(x, math.cos(theta), -1j * math.sin(theta), q, mask1, mask2)
+    if k_qubits > 6:
+        kernel_name = f"furx_kernel<{k_qubits},{q_offset},{state_mask}>"
+    else:
+        kernel_name = f"warp_furx_kernel<{k_qubits},{q_offset}>"
+        
+    code = open(Path(__file__).parent / "furx.cu").read()
+    return cp.RawModule(code=code, name_expressions=[kernel_name],options=("-std=c++17",)).get_function(kernel_name)
 
+def furx(sv: cp.ndarray, a: float, b: float, k_qubits: int, q_offset: int, state_mask:int):
+    """
+    Apply in-place fast Rx gate exp(-1j * theta * X) on k consequtive qubits to statevector array x.
 
-def furx_all(x: np.ndarray, theta: float, n_qubits: int):
+    sv: statevector
+    a: cosine factor
+    b: sine factor
+    k_qubits: number of qubits to process concurrently
+    q_offset: starting qubit number
+    state_mask: mask for indexing
+    """
+    if k_qubits > 11:
+        raise ValueError("k_qubits should be <= 11 because of shared memory constraints")
+
+    seq_kernel = get_furx_kernel(k_qubits, q_offset, state_mask)
+
+    if k_qubits > 6:
+        threads = 1 << (k_qubits-1)
+    else:
+        threads = min(32, len(sv))
+
+    seq_kernel(
+            ((len(sv)//2+threads-1)//threads,),
+            (threads,),
+            (sv, a, b))    
+
+def furx_all(sv: np.ndarray, theta: float, n_qubits: int):
     """
     Apply in-place fast uniform Rx gates exp(-1j * theta * X) to statevector array x.
-    theta: rotation angle
-    """
-    for i in range(n_qubits):
-        furx(x, theta, i)
 
+    sv: statevector
+    theta: rotation angle
+    n_qubits: total number of qubits
+    """
+    n_states = len(sv)
+    state_mask = ((n_states - 1) >> 1)
+
+    a,b = math.cos(theta), -math.sin(theta)   
+
+    group_size = 10
+    last_group_size = n_qubits%group_size
+
+    cp_sv = cp.asarray(sv)
+
+    for q_offset in range(0, n_qubits-last_group_size, group_size):
+       furx(cp_sv, a, b, group_size, q_offset, state_mask)
+
+    if last_group_size > 0:
+        furx(cp_sv, a, b, last_group_size, n_qubits-last_group_size, state_mask)
 
 ########################################
 # two-qubit XX+YY rotation

--- a/qokit/fur/nbcuda/furx.cu
+++ b/qokit/fur/nbcuda/furx.cu
@@ -1,0 +1,77 @@
+template <int n_q, int q_offset>
+__device__ uint2 get_offset(const unsigned int block_idx){
+    constexpr unsigned int stride = 1 << q_offset;
+    constexpr unsigned int index_mask = stride - 1;
+    constexpr unsigned int stride_mask = ~index_mask;
+    const unsigned int offset = ((stride_mask & block_idx) << n_q) | (index_mask & block_idx);
+
+    return {offset, stride};
+}
+
+__device__ constexpr double2 rot_x(const double a, const double b, double2& va, double2& vb){
+    double2 temp = {a*va.x - b*vb.y, a*va.y + b*vb.x};
+    vb = {a*vb.x - b*va.y, a*vb.y + b*va.x};
+    va = temp;
+}
+
+template <int n_q, int q_offset, int state_mask>
+__global__ void furx_kernel(double2* x, const double a, const double b) {
+    __shared__ double2 data[1 << n_q];
+    constexpr unsigned int stride_size = 1 << (n_q-1);
+
+    auto [offset, stride] = get_offset<n_q, q_offset>(blockIdx.x);
+    const unsigned int tid = threadIdx.x;              
+                
+    for(int i = 0; i < 2; ++i){
+        const unsigned int idx = (tid+stride_size*i);
+        data[idx] = x[offset + idx*stride];
+    }
+
+    __syncthreads();
+
+    for(int q = 0; q < n_q; ++q){
+        const unsigned int mask1 = (1 << q) - 1;
+        const unsigned int mask2 = state_mask - mask1;
+
+        const unsigned int ia = (tid & mask1) | ((tid & mask2) << 1);
+        const unsigned int ib = ia | (1 << q);
+
+        rot_x(a,b, data[ia], data[ib]);
+
+        __syncthreads();
+    }
+    
+    for(int i = 0; i < 2; ++i){
+        const unsigned int idx = (tid+stride_size*i);
+        x[offset + idx*stride] = data[idx];
+    }
+}
+
+template <int n_q, int q_offset>
+__global__ void warp_furx_kernel(double2* x, const double a, const double b) {
+    constexpr unsigned int stride_size = 1 << (n_q-1);
+    const unsigned int block_idx = blockIdx.x * blockDim.x/stride_size + threadIdx.x/stride_size;
+    auto [offset, stride] = get_offset<n_q, q_offset>(block_idx);
+
+    const unsigned int tid = threadIdx.x%stride_size;  
+    const unsigned int load_offset = offset + (tid * 2)*stride;   
+            
+    double2 v[2] = {x[load_offset], x[load_offset + stride]};
+    
+    rot_x(a, b, v[0], v[1]);
+
+    #pragma unroll
+    for(int q = 0; q < n_q-1; ++q){
+        const unsigned int warp_stride = 1 << q;
+        const bool positive = !(tid & warp_stride);
+        const unsigned int lane_idx = positive? tid + warp_stride : tid - warp_stride;
+
+        v[positive].x = __shfl_sync(0xFFFFFFFF, v[positive].x, lane_idx, stride_size);
+        v[positive].y = __shfl_sync(0xFFFFFFFF, v[positive].y, lane_idx, stride_size);
+        
+        rot_x(a, b, v[0], v[1]);
+    }
+    
+    x[offset + tid*stride] = v[0];
+    x[offset + (tid + stride_size)*stride] = v[1];
+}

--- a/qokit/fur/nbcuda/qaoa_simulator.py
+++ b/qokit/fur/nbcuda/qaoa_simulator.py
@@ -127,7 +127,7 @@ class QAOAFastSimulatorGPUBase(QAOAFastSimulatorBase):
             indices_sel = costs_t == val
         else:
             indices_sel = indices
-        return probs[indices_sel].sum()
+        return probs[indices_sel].sum().item()
 
 
 class QAOAFURXSimulatorGPU(QAOAFastSimulatorGPUBase):

--- a/qokit/labs.py
+++ b/qokit/labs.py
@@ -10,6 +10,7 @@ from itertools import combinations
 from operator import mul
 from functools import reduce
 from qokit.fur import TermsType
+from numba import njit
 
 # approximate optimal merit factor and energy for small Ns
 # from Table 1 of https://arxiv.org/abs/1512.02475
@@ -148,7 +149,7 @@ def get_energy_term_indices(N: int):
                 all_terms.append(tuple(sorted((i - 1, i + k - 1, j - 1, j + k - 1))))
     return set(all_terms), offset
 
-
+@njit()
 def energy_vals(s: Sequence, N: int | None = None) -> float:
     """Compute LABS energy values from a string of spins
 

--- a/qokit/labs.py
+++ b/qokit/labs.py
@@ -149,6 +149,7 @@ def get_energy_term_indices(N: int):
                 all_terms.append(tuple(sorted((i - 1, i + k - 1, j - 1, j + k - 1))))
     return set(all_terms), offset
 
+
 @njit()
 def energy_vals(s: Sequence, N: int | None = None) -> float:
     """Compute LABS energy values from a string of spins


### PR DESCRIPTION
## Overview
We added 2 new CUDA kernels to accelerate x-rotations. They increase the speed of each rotation by ~2.5x, based on this [benchmark](https://github.com/mebenstein-vorticity/QOKit/blob/performance/examples/benchmark_example.ipynb). 
We got the following results on a NVIDIA T4:

| **N Qubits** | **LABS (Before)** | **MaxCut (Before)** | **LABS (After)** | **MaxCut (After)** | **Improvement** |
|--------------|-------------------|---------------------|------------------|--------------------|-----------------|
|    **22**    |       1.5177      |        1.5227       |      0.5929      |       0.5926       |      2.56x      |
|    **24**    |       6.6131      |        6.6295       |      2.4754      |       2.4794       |      2.67x      |
|    **26**    |      28.5703      |       28.5143       |      11.5100     |       11.4985      |      2.48x      |

## Approach
The in-place rotation kernel is applied $n$ times for $n$ qubits to perform a single rotation. We found that for every $k < n$ steps in the operation, we can divide the state vector into $2^{n-k}$ independent sub-groups. This allows us to process groups of states independently (requiring fewer synchronizations) and ensure that for each group all memory accesses are perfectly cached. 

The `furx_kernel` uses shared memory to store all values for a given sub-group. $k$ is limited by the maximum shared memory size of the GPU and the maximum number of threads per block. For most modern GPUs we can at most allocate 64KB of shared memory per block, which is slightly below $16*2^{12}$ and thus limits us to $k \le 11$. We find that we achieve the best performance for $k = 10$, most likely because that requires only $512$ threads and achieves higher occupancy. We tried partitioning the data such that each thread is responsible for multiple rows, which gives us control over the number of threads needed independently of the shared memory requirement. Although this can lead to higher occupancy, we saw an overall decrease in performance and thus removed the partitioning. This mean $k$ is additionally limited to $\le 11$ because the kernel requires $t = 2^{k-1}$ threads per block and cuda only support a maximum of $t = 1024$.

The `warp_furx_kernel` does not use shared memory, but instead uses only registers and [warp-shuffle](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#warp-shuffle-functions) primitives to exchange data. This implies the kernel is limited to $k \le 6$ because currently each warp has 32 threads. For $k \lt 6$ each warp handles multiple groups to ensure peak occupancy. 

To perform a rotation we split up the $n$ steps into a sequence of calls to the `furx_kernel` with $k=10$ and a final call if $n$ is not a multiple of 10 to either the `furx_kernel` if $n \mod 10 \gt 6$ or the `warp_furx_kernel` otherwise. In total, instead of $n$ kernel calls, we know have $\lceil n/10 \rceil$ kernel calls for each rotation.

## Possible Future Improvements
For the  `warp_furx_kernel` we only have 4 global memory accesses per thread, and no other memory accesses. The `furx_kernel` also only has 4 global memory accesses, but has $4*k$ shared memory accesses. It is possible to incorporate the warp level exchange into this kernel and to handle it as a sequence of 2 sub-groups. For example if $k=10$, we could process this as one $k=6$ and one $k=4$ (or whatever the most efficient distribution is) sub-group, where each sub-group can work purely on the warp level. This would reduce the shared memory accesses to $8$ for each thread, and only require $2$ block-level synchronizations, instead of $k$. 

Furthermore, in terms of memory requirements, this approach of processing groups of states independently can allow us to work with a large number of qubits without requiring the whole state vector to be in memory at the same time. Groups could either be processes on multiple GPUs concurrently, or in sequence on a single GPU.