### PR TITLE
Faster X-Rotations in C

### DIFF
--- a/qokit/fur/c/csim/lib.py
+++ b/qokit/fur/c/csim/lib.py
@@ -14,16 +14,6 @@ except OSError as e:
     raise ImportError("You must compile the C simulator before running the code. Please follow the instructions in README.md") from e
 
 
-_furx = lib.furx
-_furx.restype = None
-_furx.argtypes = [
-    ndpointer(ctypes.c_double, flags="C_CONTIGUOUS"),
-    ndpointer(ctypes.c_double, flags="C_CONTIGUOUS"),
-    ctypes.c_double,
-    ctypes.c_uint,
-    ctypes.c_size_t,
-]
-
 
 _apply_qaoa_furx = lib.apply_qaoa_furx
 _apply_qaoa_furx.restype = None


### PR DESCRIPTION
Applied the same algorithm as in #62 to accelerate X-rotations in C. 
Locally we see the following speedup in the benchmark script (measured on AMD Ryzen 5950X):

- 20 qubits: 1.0x, 0.12s -> 0.12s
- 22 qubits: 1.9x, 0.47s -> 0.24s
- 24 qubits: 3.9x, 3.24s -> 0.83s

This change requires additional temporary memory. The required memory scales with the achieved parallelism and in the worst case (full parallelism) requires twice the amount of RAM. The algorithm increases cache performance and limits concurrency to large coherent blocks which reduces concurrency overhead.