### PR TITLE
Fix typos and name of function

### DIFF
--- a/qokit/dicke_state_utils.py
+++ b/qokit/dicke_state_utils.py
@@ -106,7 +106,7 @@ def blockii(n, l, qin="xxx"):
     qr = QuantumRegister(3, "blockii{}{}".format(n, l))
     circ = QuantumCircuit(qr)
 
-    # if qubit 1 is guaranteed to be 1 (even after preceeding block),
+    # if qubit 1 is guaranteed to be 1 (even after preceding block),
     # pass on to blocki without the little-endian '1'
     if qin[2] == "1":
         blocki_circ = blocki(n, l, qin[0:2])
@@ -193,7 +193,7 @@ def U(N, k=0, K=None, topology=None):
 
 
 """ dicke_simple(N,K)
-*   Based on improved techniqes upon    "Deterministic Preparation of Dicke States", https://arxiv.org/abs/1904.07358
+*   Based on improved techniques upon    "Deterministic Preparation of Dicke States", https://arxiv.org/abs/1904.07358
     with further improvements from      "On Actual Preparation of Dicke State on a Quantum Computer", https://arxiv.org/abs/2007.01681
 
 *   Generates the Dicke State through the better of the following methods:

--- a/qokit/fur/nbcuda/fur.py
+++ b/qokit/fur/nbcuda/fur.py
@@ -13,7 +13,7 @@ try:
     import cupy as cp
 except ImportError:
     if numba.cuda.is_available():
-        warnings.warn("Cupy import failed, which is required for X rotations on NVIDA GPUs", RuntimeWarning)
+        warnings.warn("Cupy import failed, which is required for X rotations on NVIDIA GPUs", RuntimeWarning)
 
 
 ########################################
@@ -35,7 +35,7 @@ def get_furx_kernel(k_qubits: int, q_offset: int, state_mask: int):
 
 def furx(sv: np.ndarray, a: float, b: float, k_qubits: int, q_offset: int, state_mask: int):
     """
-    Apply in-place fast Rx gate exp(-1j * theta * X) on k consequtive qubits to statevector array x.
+    Apply in-place fast Rx gate exp(-1j * theta * X) on k consecutive qubits to statevector array x.
 
     sv: statevector
     a: cosine factor

--- a/qokit/perf_utils.py
+++ b/qokit/perf_utils.py
@@ -23,16 +23,16 @@ def timeit(name: Optional[str] = None):
     """
     simple timer context manager
     usage 1:
-        with timeit("my awsome code"):
+        with timeit("my awesome code"):
             <some very cool stuff ...>
 
     usage 2:
-        @timeit("my awsome code"):
+        @timeit("my awesome code"):
         def my_func():
             <some very cool stuff ...>
 
     output:
-        >>> [TIME] my awsome code took <xxxx> seconds to run
+        >>> [TIME] my awesome code took <xxxx> seconds to run
     """
     start = time.monotonic()
     try:

--- a/qokit/portfolio_optimization.py
+++ b/qokit/portfolio_optimization.py
@@ -46,7 +46,7 @@ def get_configuration_cost_kw(config, po_problem=None):
 
 def po_obj_func(po_problem: dict) -> float:
     """
-    Wrapper function for compute a portofolio value
+    Wrapper function for compute a portfolio value
     """
     return partial(get_configuration_cost_kw, po_problem=po_problem)
 
@@ -86,7 +86,7 @@ def portfolio_brute_force(po_problem: dict, return_bitstring=False) -> tuple[flo
 
 def get_data(N, seed=1, real=False) -> tuple[float, float]:
     """
-    load portofolio data from qiskit-finance (Yahoo)
+    load portfolio data from qiskit-finance (Yahoo)
     https://github.com/Qiskit/qiskit-finance/blob/main/docs/tutorials/11_time_series.ipynb
     """
     import datetime
@@ -142,7 +142,7 @@ def get_data(N, seed=1, real=False) -> tuple[float, float]:
 
 
 def get_problem(N, K, q, seed=1, pre=False) -> dict[str, Any]:
-    """generate the portofolio optimziation problem dict"""
+    """generate the portfolio optimization problem dict"""
     po_problem = {}
     po_problem["N"] = N
     po_problem["K"] = K
@@ -254,7 +254,7 @@ def hamming_weight(index: str) -> int:
     return binary.count("1")
 
 
-def yield_all_indices_cosntrained(N: int, K: int):
+def yield_all_indices_constrained(N: int, K: int):
     """
     Helper function to avoid having to store all indices in memory
     """
@@ -265,7 +265,7 @@ def yield_all_indices_cosntrained(N: int, K: int):
 
 def get_sk_ini(p: int):
     """
-    scaled the sk look-up table for the application of portfolio optimziation
+    scaled the sk look-up table for the application of portfolio optimization
     """
     gamma_scale, beta_scale = 0.5, 1
     gamma, beta = get_sk_gamma_beta(p, parameterization="gamma beta")

--- a/qokit/qaoa_circuit.py
+++ b/qokit/qaoa_circuit.py
@@ -50,7 +50,7 @@ def append_cost_operator_circuit(qc: QuantumCircuit, terms: Sequence, gamma: flo
     """In the following, `gamma` is divided by factor of 2 in order
     to preserve the convention of (2 * gamma) in applying `rz` gates
     in `append_z_prod_term(...)` and that of (2 * beta) in applying `rx`
-    gates in `append_x_term(...)`, which orginates from  different conventions
+    gates in `append_x_term(...)`, which originates from  different conventions
     used between `QOKit` and `Qiskit`."""
     for term in terms:
         if len(term) == 2 and isinstance(term[1], Sequence):
@@ -79,7 +79,7 @@ def get_qaoa_circuit_from_terms(
     terms : list-like
         A sequence of `term` or `(float, term)`, where `term` is a tuple of ints.
         Each term corresponds to a summand in the cost Hamiltonian
-        and th float value is the coefficient of this term.
+        and the float value is the coefficient of this term.
         e.g. if terms = [(0.5, (0,1)), (0.3, (0,1,2,3))]
         the Hamiltonian is 0.5*Z0Z1 + 0.3*Z0Z1Z2Z3
         Unweighted Hamiltonians are supported as well:
@@ -104,7 +104,7 @@ def get_qaoa_circuit_from_terms(
         Quantum circuit implementing QAOA
     """
     assert len(betas) == len(gammas)
-    p = len(betas)  # infering number of QAOA steps from the parameters passed
+    p = len(betas)  # inferring number of QAOA steps from the parameters passed
     if qr is not None:
         assert qr.size >= N
     else:
@@ -145,7 +145,7 @@ def get_parameterized_qaoa_circuit_from_terms(
     terms : list-like
         A sequence of `term` or `(float, term)`, where `term` is a tuple of ints.
         Each term corresponds to a summand in the cost Hamiltonian
-        and th float value is the coefficient of this term.
+        and the float value is the coefficient of this term.
         e.g. if terms = [(0.5, (0,1)), (0.3, (0,1,2,3))]
         the Hamiltonian is 0.5*Z0Z1 + 0.3*Z0Z1Z2Z3
         Unweighted Hamiltonians are supported as well:

--- a/qokit/qaoa_circuit_portfolio.py
+++ b/qokit/qaoa_circuit_portfolio.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import qiskit
 import numpy as np
-from .portfolio_optimization import yield_all_indices_cosntrained, get_configuration_cost
+from .portfolio_optimization import yield_all_indices_constrained, get_configuration_cost
 from qiskit import QuantumCircuit, transpile, QuantumRegister
 from qiskit_aer import Aer
 from qiskit.circuit import ParameterVector
@@ -17,7 +17,7 @@ def generate_dicke_state_fast(N, K):
     """
     Generate the dicke state with yield function
     """
-    index = yield_all_indices_cosntrained(N, K)
+    index = yield_all_indices_constrained(N, K)
     s = np.zeros(2**N)
     for i in index:
         s[i] = 1
@@ -48,7 +48,7 @@ def get_dicke_init(N, K):
     """
     from qokit.dicke_state_utils import dicke_simple
 
-    # can be other dicke state implementaitons
+    # can be other dicke state implementations
     return dicke_simple(N, K)
 
 
@@ -74,7 +74,7 @@ def get_mixer_Txy(qc, beta, minus=False, T=None):
             # odd Exp[-j*angle*(XX+YY)]
             # qc.append(qiskit.circuit.library.XXPlusYYGate(4 * beta), [i, i + 1])
             qc.append(qiskit.circuit.library.XXPlusYYGate(4 * beta), [N - 2 - i, N - 1 - i])
-        # last uniary
+        # last unitary
         qc.append(qiskit.circuit.library.XXPlusYYGate(4 * beta), [N - 1, 0])
     return qc
 

--- a/qokit/qaoa_objective.py
+++ b/qokit/qaoa_objective.py
@@ -213,7 +213,7 @@ def get_qaoa_labs_overlap(N: int, p: int, **kwargs):
     Returns
     -------
     f : callable
-        Retrun the 1 - overlap of the state with the optimal bitstrings (we compute the sum of the probability of the output state to be in any one of the optimal bitstring states).
+        Return the 1 - overlap of the state with the optimal bitstrings (we compute the sum of the probability of the output state to be in any one of the optimal bitstring states).
     """
     return get_qaoa_labs_objective(N, p, objective="overlap", **kwargs)
 
@@ -234,7 +234,7 @@ def get_qaoa_labs_overlap_fourier(N: int, p: int, parameterization: str = "freq"
     Returns
     -------
     f : callable
-        Retrun the 1 - overlap of the state with the optimal bitstrings (we compute the sum of the probability of the output state to be in any one of the optimal bitstring states).
+        Return the 1 - overlap of the state with the optimal bitstrings (we compute the sum of the probability of the output state to be in any one of the optimal bitstring states).
     """
 
     return get_qaoa_labs_objective(N, p, objective="overlap", parameterization=parameterization, **kwargs)

--- a/qokit/qaoa_objective_labs.py
+++ b/qokit/qaoa_objective_labs.py
@@ -82,7 +82,7 @@ precomputed_labs_handler = PrecomputedLABSHandler()
 
 def get_precomputed_labs_merit_factors(N: int) -> np.ndarray:
     """
-    Return a precomputed a vector of negative LABS merit factors
+    Return a precomputed vector of negative LABS merit factors
     that accelerates the energy computation in obj_from_statevector
 
     If available, loads the precomputed vector from disk
@@ -105,7 +105,7 @@ def get_precomputed_labs_merit_factors(N: int) -> np.ndarray:
 
 def get_precomputed_optimal_bitstrings(N: int) -> np.ndarray:
     """
-    Return a precomputed  optimal bitstring for LABS problem of problem size N
+    Return a precomputed optimal bitstring for LABS problem of problem size N
 
     If available, loads the precomputed vector from disk
 

--- a/qokit/qaoa_objective_sk.py
+++ b/qokit/qaoa_objective_sk.py
@@ -33,7 +33,7 @@ def get_qaoa_sk_objective(
     p : int
         Number of QAOA layers (number of parameters will be 2*p)
     J : numpy.ndarray
-        Couplinf matrix for the SK model.
+        Coupling matrix for the SK model.
     precomputed_energies : np.array
         precomputed cuts to compute the QAOA expectation, for maximization problem
         send the precomputed cuts/energies as negative

--- a/qokit/sk.py
+++ b/qokit/sk.py
@@ -42,7 +42,7 @@ def get_sk_terms(J: np.ndarray) -> TermsType:
 
 
 def get_random_J(N: int, seed=42):
-    """Return a random coupling matrix J for a gicen N and seed.
+    """Return a random coupling matrix J for a given N and seed.
     Args:
         N (int): size of the coupling matrix.
         seed (int): random seed

--- a/qokit/utils.py
+++ b/qokit/utils.py
@@ -128,7 +128,7 @@ def precompute_energies(obj_f, nbits: int, *args: object, **kwargs: object):
     num_processes : int
         Number of processes to use. Default: 1 (serial)
         if num_processes > 1, pathos.Pool is used
-    *args, **kwargs : Objec
+    *args, **kwargs : Object
         Parameters to be passed directly to obj_f
 
     Returns


### PR DESCRIPTION
## Summary
**Fix typos**
- preceeding -> preceding
- techniqes -> techniques
- NVIDA -> NVIDIA
- consequtive -> consecutive
- awsome -> awesome
- portofolio -> portfolio
- optimziation -> optimization
- `yield_all_indices_cosntrained` to `yield_all_indices_constrained`
- orginates -> originates
- infering -> inferring
- th -> the
- implementaitons -> implementations
- uniary -> unitary
- Retrun -> Return
- Couplinf -> Coupling
- gicen -> given
- Objec -> Object